### PR TITLE
simplebot_cartv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: simplebot echo friends groupmaster help tictactoe translator webgrabber wikiquote xkcd admin shortcuts rss facebook mastodon avatar meme cuba_weather
+all: simplebot echo friends groupmaster help tictactoe translator webgrabber wikiquote xkcd admin shortcuts rss facebook mastodon avatar meme cuba_weather cartv
 
 .PHONY: simplebot
 simplebot:
@@ -8,6 +8,10 @@ simplebot:
 .PHONY: echo
 echo:
 	echo y | pip uninstall simplebot_echo; pip install plugins/simplebot_echo
+
+.PHONY: cartv
+cartv:
+	echo y | pip uninstall simplebot_cartv; pip install plugins/simplebot_cartv
 
 .PHONY: cuba_weather
 cuba_weather:

--- a/plugins/simplebot_cartv/CHANGELOG.rst
+++ b/plugins/simplebot_cartv/CHANGELOG.rst
@@ -1,0 +1,7 @@
+Changelog
+*********
+
+x.x.x
+-----
+
+- initial release

--- a/plugins/simplebot_cartv/MANIFEST.in
+++ b/plugins/simplebot_cartv/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include simplebot_cartv/locale *

--- a/plugins/simplebot_cartv/setup.py
+++ b/plugins/simplebot_cartv/setup.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import re
+import os
+
+from setuptools import setup
+
+
+MODULE_NAME = 'simplebot_cartv'
+CLASS_NAME = 'Cartv'
+with open(os.path.join(MODULE_NAME, '__init__.py'), 'rt', encoding='utf8') as fh:
+    source = fh.read()
+PLUGIN_NAME = re.search(r'name = \'(.*?)\'', source, re.M).group(1)
+VERSION = re.search(r'version = \'(.*?)\'', source, re.M).group(1)
+
+setup(
+    name=MODULE_NAME,
+    version=VERSION,
+    author='adbenitez',
+    author_email='adbenitez@nauta.cu',
+    description='A plugin for SimpleBot, a Delta Chat bot (http://delta.chat/)',
+    long_description='For more info visit https://github.com/adbenitez/simplebot',
+    long_description_content_type='text/x-rst',
+    url='https://github.com/adbenitez/simplebot',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Plugins',
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Operating System :: OS Independent',
+        'Topic :: Utilities'
+    ],
+    keywords='deltachat simplebot plugin',
+    packages=[MODULE_NAME],
+    install_requires=['simplebot', 'requests'],
+    python_requires='>=3.5',
+    entry_points={
+        'simplebot.plugins': '{} = {}:{}'.format(PLUGIN_NAME, MODULE_NAME, CLASS_NAME)
+    },
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/plugins/simplebot_cartv/simplebot_cartv/__init__.py
+++ b/plugins/simplebot_cartv/simplebot_cartv/__init__.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import gettext
+import os
+
+from simplebot import Plugin, PluginCommand
+
+import requests
+import html
+from datetime import date
+
+url = "http://www.tvcubana.icrt.cu/cartv/cartv-core/app.php?action=dia&canal={0}&fecha={1}"
+
+tv_emoji = '📺'
+cal_emoji = '📆'
+aster_emoji = '✳️'
+
+channels = [
+    'Cubavision',
+    'Telerebelde',
+    'Educativo',
+    'Educativo 2',
+    'Multivision',
+    'Canal Clave',
+    'Caribe',
+    'Habana'
+]
+
+class Cartv(Plugin):
+
+    name = 'Cartv'
+    version = '0.3.0'
+
+    @classmethod
+    def activate(cls, bot):
+        super().activate(bot)
+
+        localedir = os.path.join(os.path.dirname(__file__), 'locale')
+        lang = gettext.translation('simplebot_cartv', localedir=localedir,
+                                   languages=[bot.locale], fallback=True)
+        lang.install()
+
+        cls.description = _('Mostrar cartelera de la television cubana')
+        cls.long_description = _(
+            '/cartv <channel> ej: /cartv Cubavision o /cartv para mostrar todos los canales')
+        cls.commands = [
+            PluginCommand('/cartv', ['[text]'], _('Mostrar cartelera para el canal <text> ej: /cartv Cubavision'), cls.cartv_cmd)]
+        cls.bot.add_commands(cls.commands)
+
+    @classmethod
+    def cartv_cmd(cls, ctx):
+        chat = cls.bot.get_chat(ctx.msg)
+        today = date.today().strftime('%d-%m-%Y')
+
+        if not ctx.text:
+            for channel in channels:
+                res = requests.get(url.format(channel, today))
+                res.raise_for_status()
+                msg = cls.parser(res.text)
+                chat.send_text(msg)
+        else:
+            res = requests.get(url.format(ctx.text, today))
+            res.raise_for_status()
+            msg = cls.parser(res.text)
+            chat.send_text(msg)
+
+    @classmethod
+    def parser(cls, ogly_text):
+        lines = html.unescape(ogly_text).split('\n')
+
+        beuty_text = tv_emoji + ' ' + lines[0] + '\n'
+        beuty_text += cal_emoji + ' ' + lines[1] + '\n'
+
+        for i in range(2, len(lines)):
+            beuty_text += aster_emoji + ' ' + lines[i] + '\n'
+
+        beuty_text = beuty_text.replace('\t', ' ')
+
+        return beuty_text


### PR DESCRIPTION
Plugin para mostrar la cartelera de la TV cubana.

/cartv : Muestra todos los canales

/cartv channel_name : Muestra la cartelera de un solo canal ej. /cartv Cubavision

channels = [
    'Cubavision',
    'Telerebelde',
    'Educativo',
    'Educativo 2',
    'Multivision',
    'Canal Clave',
    'Caribe',
    'Habana'
]

Se puede implementar luego un algoritmo para hallar similitud entre lo que escribe el usuario y los canales disponibles, por ejemplo que el usuario pueda escribir Cuba o cuba y le salga Cubavision. De momento debe enviarse el nombre del canal exactamente como se ve en la lista o solicitar la cartelera para todos los canales.

En la proxima version se agrega el algoritmo de similitud.